### PR TITLE
Fix UI of blocking view for expiry date.

### DIFF
--- a/Classes/BITUpdateManager.m
+++ b/Classes/BITUpdateManager.m
@@ -493,17 +493,18 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
   
   if (!self.disableUpdateCheckOptionWhenExpired) {
     UIButton *checkForUpdateButton = [UIButton buttonWithType:kBITButtonTypeSystem];
-    checkForUpdateButton.frame = CGRectMake((frame.size.width - 140) / (CGFloat)2.0, frame.size.height - 100, 140, 25);
+    checkForUpdateButton.frame = CGRectMake((frame.size.width - 240) / (CGFloat)2.0, frame.size.height - 150, 240, 75);
     [checkForUpdateButton setTitle:BITHockeyLocalizedString(@"UpdateButtonCheck") forState:UIControlStateNormal];
     [checkForUpdateButton addTarget:self
                              action:@selector(checkForUpdateForExpiredVersion)
-                   forControlEvents:UIControlEventTouchUpInside];
+                   forControlEvents:UIControlEventPrimaryActionTriggered];
+
     [self.blockingView addSubview:checkForUpdateButton];
   }
   
   if (message != nil) {
     frame.origin.x = 20;
-    frame.origin.y = frame.size.height - 180;
+    frame.origin.y = frame.size.height - 250;
     frame.size.width -= 40;
     frame.size.height = 70;
     


### PR DESCRIPTION
When `expiryDate` is set for `BITUpdateManager` the app is locking with a screen like on the attached screenshot. We have a shrinked button with` ... `text and nothing is happening when we tap it.

**Reprosteps**:
1. Set expiryDate for app version
```
class AppDelegate: UIResponder, UIApplicationDelegate {
...
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
      ...
      let formatter = DateFormatter()
      formatter.dateFormat = "yyyy/MM/dd HH:mm"
      BITHockeyManager.shared().updateManager.expiryDate = formatter.date(from: "2018/10/23 12:00") //yesterday date
      ...
   }
...
}
```
2. Open app

**_Actual_**: Button UI is broken. Button not worked.
**_Expected_**: Button name is "CHECK". Button invokes check update.

**Before**:
![screenshot 2018-10-24 at 17 13 15](https://user-images.githubusercontent.com/40772628/47437389-25e8d800-d7b1-11e8-9ccc-dfe43427a06b.png)


**After**:
![screenshot 2018-10-24 at 17 18 05](https://user-images.githubusercontent.com/40772628/47437249-da362e80-d7b0-11e8-98af-0a8912a980e4.png)
